### PR TITLE
Fix fdk-aac path

### DIFF
--- a/centos_basic_ffmpeg_installer.sh
+++ b/centos_basic_ffmpeg_installer.sh
@@ -183,7 +183,7 @@ function update {
 
 	# Update libfdk_aac
 	echo "Updating libfdk_aac.."
-	cd ~/ffmpeg_sources/fdk_aac
+	cd ~/ffmpeg_sources/fdk-aac
 	make distclean
 	git pull
 	./configure --prefix="$HOME/ffmpeg_build" --disable-shared


### PR DESCRIPTION
From your install routine:

```
git clone --depth 1 git://git.code.sf.net/p/opencore-amr/fdk-aac
```

However, the update routine uses `fdk_aac` as folder name. This is incorrect.