### PR TITLE
make sure correct nasm version is installed

### DIFF
--- a/centos_basic_ffmpeg_installer.sh
+++ b/centos_basic_ffmpeg_installer.sh
@@ -29,6 +29,11 @@ Choose an option below:
 function install {
 
 	echo "Installing dependencies..!"
+	if [ ! -f "/etc/yum.repo.d/nasm.repo" ]
+	 then
+		cd /etc/yum.repo.d/
+		wget http://nasm.us/nasm.repo
+	 fi
 	 yum install autoconf automake cmake freetype-devel gcc gcc-c++ git libtool make mercurial nasm pkgconfig zlib-devel -y
 
 	 mkdir ~/ffmpeg_sources


### PR DESCRIPTION
On the CentOS 7 install I used this with, the default yum repos only referenced nasm 2.10. libx264 requires at least nasm 2.13 to compile. This change wget's the yum repo from the nasm website to make sure the latest version of nasm is installed.